### PR TITLE
Functionality modifications made

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # nest_influx
 Push Nest to influxdb
 
+Changes to Original Version:
+- Made compatible with "Range" mode (setting simultaneous high and low temp targets)
+- Made Fahrenheit conversion configurable: default is to convert to F, changing "convert_to_Fahrentheit" to False in config.ini will keep measurements in Celsius
+- Added comments to explain functionality
+- Commented out unnecessary(?) metrics, currently only records mode, fan, humidity, hvac_ac_state, temperature, target (AC), and target_heat (heat). Thesee can be re-activated by uncommenting the line in nest_push.py.
+
+A new sample Grafana xml has not yet been generated, but target_heat can now be used to show the heat target as a discrete measurement (target_heat), while AC target remains as its own measurement (target). For example, if "range" mode is used, Grafana can show the high and low setpoints simultaneously.
+
+
+Original Version:
 Iterates through all structures and devices to create the following metrics:
 
 * mode

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nest_influx
 Push Nest to influxdb
 
-Modified from https://github.com/kremlinkev/nest_influx
+Modified from original version by https://github.com/kremlinkev/nest_influx
 
 ###Changes to Original Version:
 - Made compatible with "Range" mode (setting simultaneous high and low temp targets)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # nest_influx
 Push Nest to influxdb
 
-Changes to Original Version:
+Modified from https://github.com/kremlinkev/nest_influx
+
+###Changes to Original Version:
 - Made compatible with "Range" mode (setting simultaneous high and low temp targets)
 - Made Fahrenheit conversion configurable: default is to convert to F, changing "convert_to_Fahrentheit" to False in config.ini will keep measurements in Celsius
 - Added comments to explain functionality
@@ -10,7 +12,7 @@ Changes to Original Version:
 A new sample Grafana xml has not yet been generated, but target_heat can now be used to show the heat target as a discrete measurement (target_heat), while AC target remains as its own measurement (target). For example, if "range" mode is used, Grafana can show the high and low setpoints simultaneously.
 
 
-Original Version:
+##Original Version:
 Iterates through all structures and devices to create the following metrics:
 
 * mode

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,3 +1,5 @@
+convert_to_Fahrenheit = True
+
 [nest]
 user = user@email.com
 pass = lolpassword

--- a/nest_push.py
+++ b/nest_push.py
@@ -1,12 +1,15 @@
+#!/usr/local/bin/python3
 import sys
-
 import nest
-
 from configobj import ConfigObj
 from influxdb import InfluxDBClient
 from nest import utils as nu
+from validate import Validator
 
-config = ConfigObj(sys.path[0] + '/config.ini')
+# Gather details from config.ini and process
+config = ConfigObj(sys.path[0] + '/config.ini', configspec=['convert_to_Fahrenheit = boolean(default=True)'])
+config.validate(Validator(), copy=True)
+convert_to_Fahrenheit = config['convert_to_Fahrenheit']
 USER = config['nest']['user']
 PASS = config['nest']['pass']
 IFLX_HOST = config['influx']['host']
@@ -14,30 +17,20 @@ IFLX_USER = config['influx']['user']
 IFLX_PASS = config['influx']['pass']
 IFLX_DB = config['influx']['database']
 
-# Metrics to loop
-metrics = ['mode',
-           'fan',
-           'humidity',
-           'hvac_ac_state',
-           'hvac_cool_x2_state',
-           'hvac_heater_state',
-           'hvac_aux_heater_state',
-           'hvac_heat_x2_state',
-           'hvac_heat_x3_state',
-           'hvac_alt_heat_state',
-           'hvac_alt_heat_x2_state',
-           'hvac_emer_heat_state']
+# Metrics to loop, uncomment any your system is capable of
+metrics = ['fan',                      # Fan state
+           'hvac_ac_state',            # Air Conditioning state
+           #'hvac_cool_x2_state',      # Unsure of function
+           'hvac_heater_state',        # Heater state
+           #'hvac_aux_heater_state',   # Unsure of function
+           #'hvac_heat_x2_state',      # Unsure of function
+           #'hvac_heat_x3_state',      # Unsure of function
+           #'hvac_alt_heat_state',     # Unsure of function 
+           #'hvac_alt_heat_x2_state',  # Unsure of function 
+           #'hvac_emer_heat_state',    # Unsure of function
+           'humidity']                 # Measures current indoor humidity
 
-metrics_convert = ['temperature',
-                   'target']
-
-
-def send_to_influx(metrics, host=IFLX_HOST, port=8086, user=IFLX_USER,
-                   pwd=IFLX_PASS, db=IFLX_DB):
-    client = InfluxDBClient(host, port, user, pwd, db)
-    client.write_points(metrics)
-
-
+# Function to gather data from Nest
 def gather_nest(u=USER, p=PASS):
     napi = nest.Nest(u, p)
     data = []
@@ -46,33 +39,89 @@ def gather_nest(u=USER, p=PASS):
     for structure in napi.structures:
         struct_name = structure.name
 
+        # loop through each of the Nest devices present in the account
         for device in structure.devices:
+
+            # these values are reset to null in case they aren't used in this loop
+            device_mode = None
+            target_heat = None
+            target_cool = None
+        
+            # loop through and record each of the metrics defined above
             for m in metrics:
                 data.append({'measurement': m,
                              'tags': {'structure': struct_name,
                                       'device': device.name},
                              'fields': {'value': getattr(device, m)}})
 
-            for m in metrics_convert:
-                data.append({'measurement': m,
+            # process current indoor temperature
+            data.append({'measurement': 'temperature',
+                         'tags': {'structure': struct_name,
+                                  'device': device.name},
+                         'fields': {'value': convert(getattr(device,'temperature'))}})
+
+            # get current mode of device to properly process target temps
+            device_mode = getattr(device, 'mode')
+            data.append({'measurement': 'mode',
+                         'tags': {'structure': struct_name,
+                                  'device': device.name},
+                         'fields': {'value': device_mode}})
+
+            # process target temps based on mode 
+            if device_mode == "cool": # AC only
+                target_heat=None
+                target_cool=convert(getattr(device,'target'))
+            elif device_mode == "heat": # heater only
+                target_heat=convert(getattr(device,'target'))
+                target_cool=None
+            elif device_mode == "range": #high and low set points
+                target_heat=convert(getattr(device,'target').low)
+                target_cool=convert(getattr(device,'target').high)
+            else: #off or other unhandled mode
+                target_heat=None
+                target_cool=None
+
+            # record target_heat if it is set
+            if target_heat is not None:
+                data.append({'measurement': 'target_heat',
                              'tags': {'structure': struct_name,
                                       'device': device.name},
-                             'fields': {'value':
-                                        nu.c_to_f(getattr(device, m))}})
+                             'fields': {'value':target_heat}})
 
-        t = nu.c_to_f(structure.weather.current.temperature)
+            # record target_cool if it is set
+            if target_cool is not None:
+                data.append({'measurement': 'target',
+                             'tags': {'structure': struct_name,
+                                      'device': device.name},
+                             'fields': {'value':target_cool}})
+
+        # record current outside temperature (wherever Nest gets this from)
         data.append({'measurement': 'temperature',
                      'tags': {'structure': struct_name,
                               'device': 'Outside'},
-                     'fields': {'value':  t}})
+                     'fields': {'value':  convert(structure.weather.current.temperature)}})
 
+        # record current outside humidity (wherever Nest gets this from)
         data.append({'measurement': 'humidity',
                      'tags': {'structure': struct_name,
                               'device': 'Outside'},
                      'fields': {'value': structure.weather.current.humidity}})
-
     return data
 
+# Function to send data gathered to influxDB
+def send_to_influx(metrics, host=IFLX_HOST, port=8086, user=IFLX_USER,
+                   pwd=IFLX_PASS, db=IFLX_DB):
+    client = InfluxDBClient(host, port, user, pwd, db)
+    client.write_points(metrics)
+
+# Function to convert Celsius temps to Fahrenheit if option is set in config.ini
+def convert(value):
+    if convert_to_Fahrenheit:
+       converted = nu.c_to_f(value)
+    else:
+       converted = value
+    return converted
+
+# Main body of program
 if __name__ == '__main__':
-    data = gather_nest()
-    send_to_influx(data)
+    send_to_influx(gather_nest())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 configobj
 influxdb
 python-nest
+validate


### PR DESCRIPTION
I've made some changes to the original code to improve functionality: 
- Made compatible with "Range" mode (setting simultaneous high and low temp targets)
- Made Fahrenheit conversion configurable: default is to convert to F, changing "convert_to_Fahrentheit" to False in config.ini will keep measurements in Celsius
- Added comments to explain functionality
- Commented out unnecessary(?) metrics, currently only records mode, fan, humidity, hvac_ac_state, temperature, target (AC), and target_heat (heat). These can be re-activated by uncommenting the line in nest_push.py.

This started out with me just trying to add support for range mode, and then i started tweaking and commenting things and now here we are. Hope it's cool with you.
